### PR TITLE
refactor: manual and auto events emitter

### DIFF
--- a/src/confirmator.ts
+++ b/src/confirmator.ts
@@ -4,22 +4,23 @@ import type { BlockHeader, Eth } from 'web3-eth'
 
 import { Event } from './event.model'
 import { asyncSplit, initLogger, setDifference } from './utils'
-import type { Confirmator, ConfirmatorOptions, EventsEmitter, Logger } from './definitions'
+import type { Confirmator, ConfirmatorOptions, Logger } from './definitions'
 import type { BlockTracker } from './block-tracker'
-import { INVALID_CONFIRMATION_EVENT_NAME, NEW_CONFIRMATION_EVENT_NAME, NEW_EVENT_EVENT_NAME } from './definitions'
+import { INVALID_CONFIRMATION_EVENT_NAME, NEW_CONFIRMATION_EVENT_NAME } from './definitions'
+import { ManualEventsEmitter } from './events'
 
 const DEFAULT_WAITING_BLOCK_COUNT = 10
 
 function isConfirmedClosure (currentBlockNumber: number) {
-  return (event: Event): boolean => event.getConfirmationsCount(currentBlockNumber) >= event.targetConfirmation
+  return (event: Event): boolean => !event.emitted && event.getConfirmationsCount(currentBlockNumber) >= event.targetConfirmation
 }
 
 /**
  * Class that handles confirmations of blocks.
  * Also gives support to detect what events were dropped.
  */
-export class ModelConfirmator implements Confirmator {
-  private readonly emitter: EventsEmitter<any>
+export class ModelConfirmator<T extends EventLog> implements Confirmator<T> {
+  private readonly emitter: ManualEventsEmitter<T>
   private readonly eth: Eth
   private readonly contractAddress: string
   private readonly blockTracker: BlockTracker
@@ -31,7 +32,7 @@ export class ModelConfirmator implements Confirmator {
    */
   private readonly waitingBlockCount: number
 
-  constructor (emitter: EventsEmitter<any>, eth: Eth, contractAddress: string, blockTracker: BlockTracker, { baseLogger, waitingBlockCount }: ConfirmatorOptions = {}) {
+  constructor (emitter: ManualEventsEmitter<T>, eth: Eth, contractAddress: string, blockTracker: BlockTracker, { baseLogger, waitingBlockCount }: ConfirmatorOptions = {}) {
     this.emitter = emitter
     this.eth = eth
     this.contractAddress = contractAddress
@@ -47,7 +48,15 @@ export class ModelConfirmator implements Confirmator {
    *
    * @param currentBlock
    */
-  public async runConfirmationsRoutine (currentBlock: BlockHeader): Promise<void> {
+  public async runConfirmationsRoutine (currentBlock: BlockHeader): Promise<T[]> {
+    if (typeof currentBlock.number !== 'number') {
+      throw new TypeError('CurrentBlock.number is not a number!')
+    }
+
+    if (typeof this.waitingBlockCount !== 'number') {
+      throw new TypeError('waitingBlockCount is not a number!')
+    }
+
     this.logger.verbose('Running Confirmation routine')
     const events = await Event.findAll({
       where: {
@@ -57,29 +66,15 @@ export class ModelConfirmator implements Confirmator {
     })
 
     if (!events) {
-      return
+      return []
     }
 
     const [valid, invalid] = await asyncSplit(events, this.eventHasValidReceipt.bind(this))
-    const toBeEmitted = valid.filter(isConfirmedClosure(currentBlock.number))
-
-    toBeEmitted.forEach(this.confirmEvent.bind(this))
-    this.logger.info(`Confirmed ${toBeEmitted.length} events.`)
-    await Event.update({ emitted: true }, { where: { id: toBeEmitted.map(e => e.id) } }) // Update DB that events were emitted
-
     valid.forEach(this.emitNewConfirmationsClosure(currentBlock.number))
 
     if (invalid.length !== 0) {
       invalid.forEach(e => this.emitter.emit(INVALID_CONFIRMATION_EVENT_NAME, { transactionHash: e.transactionHash }))
       await Event.destroy({ where: { id: invalid.map(e => e.id) } })
-    }
-
-    if (typeof currentBlock.number !== 'number') {
-      throw new TypeError('CurrentBlock.number is not a number!')
-    }
-
-    if (typeof this.waitingBlockCount !== 'number') {
-      throw new TypeError('waitingBlockCount is not a number!')
     }
 
     // Remove already too old confirmations
@@ -90,6 +85,11 @@ export class ModelConfirmator implements Confirmator {
         blockNumber: { [Op.lte]: literal(`${currentBlock.number - this.waitingBlockCount} - \`targetConfirmation\``) }
       }
     })
+
+    const toBeEmitted = valid.filter(isConfirmedClosure(currentBlock.number))
+    this.logger.info(`Confirmed ${toBeEmitted.length} events.`)
+    await Event.update({ emitted: true }, { where: { id: toBeEmitted.map(e => e.id) } }) // Update DB that events were emitted
+    return toBeEmitted.map(this.confirmEvent.bind(this))
   }
 
   private async eventHasValidReceipt (event: Event): Promise<boolean> {
@@ -116,16 +116,10 @@ export class ModelConfirmator implements Confirmator {
     }
   }
 
-  private confirmEvent (data: Event): void {
-    // If it was already emitted then ignore this
-    if (data.emitted) {
-      return
-    }
-
-    const event = JSON.parse(data.content) as EventLog
+  private confirmEvent (data: Event): T {
+    const event = JSON.parse(data.content) as T
     this.logger.debug('Confirming event', event)
-    this.blockTracker.setLastProcessedBlockIfHigher(event.blockNumber, event.blockHash)
-    this.emitter.emit(NEW_EVENT_EVENT_NAME, event).catch(e => this.emitter.emit('error', e))
+    return event
   }
 
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -83,6 +83,10 @@ export interface ProgressInfo {
    * If confirmations are enabled, then the first batch is with confirmed events.
    */
   stepsComplete: number
+
+  /**
+   * Number of total batches that gonna be emitted
+   */
   totalSteps: number
   stepFromBlock: number
   stepToBlock: number
@@ -108,8 +112,19 @@ export type EventsEmitterEmptyEvents = keyof {
 }
 
 export type EventsEmitterCreationOptions = {
+  /**
+   * Instance of custom BlockTracker used for the Events Emitter
+   */
   blockTracker?: BlockTracker
+
+  /**
+   * NewBlockEmitter instance or its options that will be used to create it
+   */
   newBlockEmitter?: NewBlockEmitter | NewBlockEmitterOptions
+
+  /**
+   * Custom Logger instance.
+   */
   logger?: Logger
 } & ManualEventsEmitterOptions
 
@@ -122,7 +137,7 @@ export interface ManualEventsEmitterOptions {
    *
    * Each topic can also be a nested array of topics that behaves as “or” operation between the given nested topics.
    *
-   * The topics are sha3 hashed so no need to that yourself!
+   * The topics are sha3 hashed so no need to do that yourself!
    *
    * It has priority over the "events" option.
    *
@@ -163,6 +178,8 @@ export interface AutoEventsEmitterOptions extends ManualEventsEmitterOptions{
    *
    * This effects if you have multiple listeners on the EventsEmitter, where it will be awaited
    * for a listener to finish (eq. if it returns Promise, then to be resolved) before moving to next listeners.
+   *
+   * By default this is false.
    */
   serialListeners?: boolean
 
@@ -170,12 +187,15 @@ export interface AutoEventsEmitterOptions extends ManualEventsEmitterOptions{
    * Defines if the events should be kept in order and processed serially.
    *
    * This will await for the processing of a event to finish before moving to next event.
+   *
+   * By default this is false.
    */
   serialProcessing?: boolean
 
   /**
-   * Defines if the EventsEmitter should automatically start listening on events when a events listener
+   * Defines if the EventsEmitter should automatically start listening on events when an events listener
    * for events is attached.
+   *
    * By default this is true.
    */
   autoStart?: boolean

--- a/src/events.ts
+++ b/src/events.ts
@@ -77,7 +77,7 @@ export class ManualEventsEmitter<E extends EventLog> extends Emittery.Typed<Manu
    * If nothing was fetched yet, then fetching starts from configured startingBlock or genesis block.
    * If there is nothing to fetch (eq. from last call no new block was created on the chain) then empty array is returned.
    *
-   * @param currentBlock - Is the latest block on blockchain, serves as optimalization if you have already the information available.
+   * @param currentBlock - Is the latest block on a blockchain, serves as optimization if you have already the information available.
    * @yields Batch object
    */
   public async * fetch (currentBlock?: BlockHeader): AsyncIterableIterator<Batch<E>> {
@@ -330,7 +330,7 @@ export class ManualEventsEmitter<E extends EventLog> extends Emittery.Typed<Manu
 /**
  * EventsEmitter implementation that listens on new blocks on blockchain and then automatically emits new events.
  *
- * Polling is triggered using the NewBlockEmitter and is therefore up to the user
+ * Fetching is triggered using the NewBlockEmitter and is therefore up to the user
  * to chose what new-block strategy will employ.
  */
 export class AutoEventsEmitter<E extends EventLog> extends AutoStartStopEventEmitter<AutoEventsEmitterEventsName<E>, EventsEmitterEmptyEvents> {

--- a/src/events.ts
+++ b/src/events.ts
@@ -2,58 +2,58 @@ import { PastEventOptions } from 'web3-eth-contract'
 import { Sema } from 'async-sema'
 import type { BlockHeader, Eth } from 'web3-eth'
 import { EventLog } from 'web3-core'
+import Emittery from 'emittery'
 
 import { Contract } from './contract'
 import { Event } from './event.model'
 import {
-  EventsEmitter, EventsEmitterEventsNames, EventsEmitterEmptyEvents,
-  EventsEmitterOptions,
+  ManualEventsEmitterEventsNames, EventsEmitterEmptyEvents,
+  ManualEventsEmitterOptions,
   Logger,
   NewBlockEmitter,
   NEW_BLOCK_EVENT_NAME,
   NEW_EVENT_EVENT_NAME,
-  REORG_EVENT_NAME, REORG_OUT_OF_RANGE_EVENT_NAME, PROGRESS_EVENT_NAME, Batch
+  REORG_EVENT_NAME, REORG_OUT_OF_RANGE_EVENT_NAME, PROGRESS_EVENT_NAME, Batch, AutoEventsEmitterOptions,
+  INVALID_CONFIRMATION_EVENT_NAME, NEW_CONFIRMATION_EVENT_NAME, AutoEventsEmitterEventsName
 } from './definitions'
-import { AutoStartStopEventEmitter, errorHandler, hashTopics, initLogger, split } from './utils'
+import { AutoStartStopEventEmitter, errorHandler, hashTopics, initLogger, passTroughEvents, split } from './utils'
 import { ModelConfirmator } from './confirmator'
 import type { BlockTracker } from './block-tracker'
 import type { EventInterface } from './event.model'
 
+const DEFAULT_BATCH_SIZE = 120 // 120 blocks = RSK one hour of blocks
+
 /**
- * Base class for EventsEmitter.
+ * EventsEmitter implementation where you have to manually call fetch() function to get events.
+ * It still supports emitting of all events like AutoEventsEmitter excecept the 'newEvent' with events.
  * It supports block's confirmation, where new events are stored to DB and only after configured number of new
  * blocks are emitted to consumers for further processing.
  */
-export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartStopEventEmitter<EventsEmitterEventsNames<E>, EventsEmitterEmptyEvents> implements EventsEmitter<E> {
+export class ManualEventsEmitter<E extends EventLog> extends Emittery.Typed<ManualEventsEmitterEventsNames, EventsEmitterEmptyEvents> {
   public readonly blockTracker: BlockTracker
   public readonly contract: Contract
-  protected readonly newBlockEmitter: NewBlockEmitter
   protected readonly startingBlock: number
   protected readonly eventNames?: string[]
   protected readonly eth: Eth
   protected readonly semaphore: Sema
   protected readonly confirmations: number
   protected readonly topics?: (string[] | string)[]
-  private readonly serialListeners?: boolean
-  private readonly serialProcessing?: boolean
-  private readonly confirmator?: ModelConfirmator
+  protected readonly logger: Logger
+  private confirmator?: ModelConfirmator<E>
   private readonly batchSize: number
-  private confirmationRoutine?: (...args: any[]) => void
 
-  protected constructor (eth: Eth, contract: Contract, blockTracker: BlockTracker, newBlockEmitter: NewBlockEmitter, baseLogger: Logger, options?: EventsEmitterOptions) {
-    super(initLogger('', baseLogger), NEW_EVENT_EVENT_NAME, options?.autoStart)
+  constructor (eth: Eth, contract: Contract, blockTracker: BlockTracker, baseLogger: Logger, options?: ManualEventsEmitterOptions) {
+    super()
+    this.logger = initLogger('', baseLogger)
     this.eth = eth
     this.contract = contract
     this.eventNames = options?.events
     this.startingBlock = options?.startingBlock ?? 0
     this.confirmations = options?.confirmations ?? 0
     this.topics = hashTopics(options?.topics)
-    this.batchSize = options?.batchSize ?? 120 // 120 blocks = RSK one hour of blocks
+    this.batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE
     this.semaphore = new Sema(1) // Allow only one caller
     this.blockTracker = blockTracker
-    this.newBlockEmitter = newBlockEmitter
-    this.serialListeners = options?.serialListeners
-    this.serialProcessing = options?.serialProcessing
 
     if (typeof this.startingBlock !== 'number') {
       throw new TypeError('startingBlock has to be a number!')
@@ -62,8 +62,6 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
     if (!this.topics && !this.eventNames) {
       throw new Error('You have to specify options.topics or options.events!')
     }
-
-    this.newBlockEmitter.on('error', (e) => this.emit('error', e))
 
     if (this.confirmations > 0 && options?.confirmator !== null) {
       if (options?.confirmator instanceof ModelConfirmator) {
@@ -77,56 +75,40 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
   /**
    * Method that will fetch Events from the last fetched block.
    * If nothing was fetched yet, then fetching starts from configured startingBlock or genesis block.
+   * If there is nothing to fetch (eq. from last call no new block was created on the chain) then empty array is returned.
+   *
+   * @param currentBlock - Is the latest block on blockchain, serves as optimalization if you have already the information available.
    * @yields Batch object
    */
-  public async * fetch (): AsyncIterableIterator<Batch<E>> {
+  public async * fetch (currentBlock?: BlockHeader): AsyncIterableIterator<Batch<E>> {
     await this.semaphore.acquire()
+    this.logger.verbose('Lock acquired for fetch()')
     try {
-      let from: number
+      const fromNumber = this.blockTracker.getLastFetchedBlock()[0] ?? this.startingBlock
+      const toBlock = currentBlock ?? await this.eth.getBlock('latest')
 
-      const currentBlock = await this.eth.getBlock('latest')
-      const lastFetchedBlockNumber = this.blockTracker.getLastFetchedBlock()[0]
+      // Nothing new, lets fast-forward
+      if (fromNumber === toBlock.number) {
+        this.logger.verbose('Nothing new to process')
+        return
+      }
 
-      if (lastFetchedBlockNumber) {
-        from = lastFetchedBlockNumber
-      } else {
-        from = this.startingBlock
+      // Check if reorg did not happen since the last poll
+      if (this.confirmations && await this.isReorg()) {
+        return this.handleReorg(toBlock)
       }
 
       // Pass through the data from batch
-      yield * this.batchFetchAndProcessEvents(from as number, currentBlock.number, currentBlock)
+      yield * this.batchFetchAndProcessEvents(
+        // +1 because fromBlock and toBlock are "or equal", eq. closed interval, so we need to avoid duplications
+        this.blockTracker.getLastFetchedBlock()[0] !== undefined ? fromNumber + 1 : fromNumber,
+        toBlock.number,
+        toBlock
+      )
     } finally {
       this.semaphore.release()
     }
   }
-
-  public start (): void {
-    this.startEvents()
-
-    if (this.confirmations > 0 && this.confirmator) {
-      this.logger.verbose('Attaching Confirmations to New Block event')
-      this.confirmationRoutine = errorHandler(this.confirmator.runConfirmationsRoutine.bind(this.confirmator), this.logger)
-      this.newBlockEmitter.on(NEW_BLOCK_EVENT_NAME, this.confirmationRoutine)
-    }
-  }
-
-  public stop (): void {
-    this.stopEvents()
-
-    if (this.confirmationRoutine) {
-      this.newBlockEmitter.off(NEW_BLOCK_EVENT_NAME, this.confirmationRoutine)
-    }
-  }
-
-  /**
-   * Start fetching new events. Depends on specified strategy
-   */
-  protected abstract startEvents (): void
-
-  /**
-   * Stop fetching new events. Depends on specified strategy.
-   */
-  protected abstract stopEvents (): void
 
   /**
    * Method for processing events. It splits the events based on if they need more confirmations.
@@ -161,6 +143,11 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
     this.logger.info(`${eventsToBeConfirmed.length} events to be confirmed.`)
     await Event.bulkCreate(eventsToBeConfirmed.map(this.serializeEvent.bind(this))) // Lets store them to DB
 
+    if (eventsToBeEmitted.length > 0) {
+      const lastEvent = eventsToBeEmitted[eventsToBeEmitted.length - 1]
+      this.blockTracker.setLastProcessedBlockIfHigher(lastEvent.blockNumber, lastEvent.blockHash)
+    }
+
     return eventsToBeEmitted
   }
 
@@ -174,7 +161,7 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
    */
   protected async * batchFetchAndProcessEvents (fromBlock: number, toBlock: number, currentBlock: BlockHeader): AsyncIterableIterator<Batch<E>> {
     if (typeof fromBlock !== 'number' || typeof toBlock !== 'number') {
-      throw new TypeError('fromBlock and toBlock has to be numbers!')
+      throw new TypeError(`fromBlock and toBlock has to be numbers! Got from: ${fromBlock}; to: ${toBlock}`)
     }
 
     if (toBlock < fromBlock) {
@@ -188,24 +175,63 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
     }
 
     const startTime = process.hrtime()
-    const countOfBatches = toBlock === fromBlock ? 1 : Math.ceil((toBlock - fromBlock) / (this.batchSize - 1))
+
     this.logger.info(`Fetching and processing events from block ${fromBlock} to ${toBlock}`)
-    this.logger.verbose(`Will process ${countOfBatches} batches`)
+    this.logger.debug(`Batch size is ${this.batchSize}`)
 
-    for (let batch = 0; batch < countOfBatches; batch++) {
+    let batchOffset = 0
+    let batch = 0
+    let startBatching = true
+    const countOfBatches = Math.ceil((toBlock - fromBlock + 1) / this.batchSize)
+
+    // If confirmations are enabled then first batch is with confirmed events
+    // only run if this is not the first time running.
+    if (this.confirmator && this.blockTracker.getLastFetchedBlock()[0]) {
+      const confirmedEvents = await this.confirmator.runConfirmationsRoutine(currentBlock)
+
+      if (confirmedEvents.length > 0) {
+        batchOffset += 1
+        const lastEvent = confirmedEvents[confirmedEvents.length - 1]
+        this.logger.verbose('Emitting Batch with Confirmed events')
+
+        yield {
+          stepsComplete: 1,
+          totalSteps: countOfBatches + batchOffset,
+          stepFromBlock: this.blockTracker.getLastProcessedBlock()[0]!,
+          stepToBlock: lastEvent.blockNumber,
+          events: confirmedEvents
+        }
+        this.blockTracker.setLastProcessedBlockIfHigher(lastEvent.blockNumber, lastEvent.blockHash)
+
+        this.emit(PROGRESS_EVENT_NAME, {
+          stepsComplete: batch + 1,
+          totalSteps: countOfBatches,
+          stepFromBlock: this.blockTracker.getLastProcessedBlock()[0]!,
+          stepToBlock: lastEvent.blockNumber
+        }).catch(e => this.emit('error', e))
+      }
+    }
+
+    this.logger.verbose(`Will process ${countOfBatches + batchOffset} batches`)
+
+    for (; batch < countOfBatches; batch++) {
       // The first batch starts at fromBlock sharp, but the others has to start +1 to avoid reprocessing of the bordering block
-      let batchFromBlock, batchToBlock
+      let batchFromBlock
 
-      if (batch === 0) {
+      if (startBatching) {
         batchFromBlock = fromBlock
-        batchToBlock = Math.min(batchFromBlock + this.batchSize - 1, toBlock)
+        startBatching = false
       } else {
         batchFromBlock = fromBlock + (batch * this.batchSize)
-        batchToBlock = Math.min(batchFromBlock + this.batchSize - 1, toBlock)
+      }
+
+      const batchToBlock = Math.min(batchFromBlock + this.batchSize - 1, toBlock)
+
+      if (countOfBatches > 1) {
+        this.logger.verbose(`Processing batch no. ${batch + 1}: from block ${batchFromBlock} to ${batchToBlock}`)
       }
 
       const batchToBlockHeader = await this.eth.getBlock(batchToBlock)
-      this.logger.verbose(`Processing batch no. ${batch + 1}: from block ${batchFromBlock} to ${batchToBlock}`)
       const events = (await this.contract.getPastEvents('allEvents', {
         fromBlock: batchFromBlock,
         toBlock: batchToBlock,
@@ -216,24 +242,27 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
       const confirmedEvents = await this.processEvents(events, currentBlock.number)
       this.blockTracker.setLastFetchedBlock(batchToBlockHeader.number, batchToBlockHeader.hash)
       yield {
-        stepsComplete: batch + 1,
-        totalSteps: countOfBatches,
+        stepsComplete: batch + batchOffset + 1,
+        totalSteps: countOfBatches + batchOffset,
         stepFromBlock: batchFromBlock,
         stepToBlock: batchToBlock,
         events: confirmedEvents
       }
+
+      this.emit(PROGRESS_EVENT_NAME, {
+        stepsComplete: batch + batchOffset + 1,
+        totalSteps: countOfBatches + batchOffset,
+        stepFromBlock: batchFromBlock,
+        stepToBlock: batchToBlock
+      }).catch(e => this.emit('error', e))
     }
 
     const [secondsLapsed] = process.hrtime(startTime)
     this.logger.info(`Finished fetching events in ${secondsLapsed}s`)
   }
 
-  protected async convertIteratorToEmitter (iter: AsyncIterableIterator<Batch<E>>): Promise<void> {
-    for await (const batch of iter) {
-      await this.emitEvents(batch.events)
-      delete batch.events
-      this.emit(PROGRESS_EVENT_NAME, batch).catch(e => this.emit('error', e))
-    }
+  public setConfirmator (confirmator: ModelConfirmator<E>): void {
+    this.confirmator = confirmator
   }
 
   protected async isReorg (): Promise<boolean> {
@@ -285,6 +314,54 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
     this.blockTracker.setLastFetchedBlock(currentBlock.number, currentBlock.hash)
   }
 
+  private serializeEvent (data: EventLog): EventInterface {
+    this.logger.debug(`New ${data.event} event to be confirmed. Block ${data.blockNumber}, transaction ${data.transactionHash}`)
+    return {
+      blockNumber: data.blockNumber,
+      transactionHash: data.transactionHash,
+      contractAddress: this.contract.address,
+      event: data.event,
+      targetConfirmation: this.confirmations,
+      content: JSON.stringify(data)
+    }
+  }
+}
+
+/**
+ * EventsEmitter implementation that listens on new blocks on blockchain and then automatically emits new events.
+ *
+ * Polling is triggered using the NewBlockEmitter and is therefore up to the user
+ * to chose what new-block strategy will employ.
+ */
+export class AutoEventsEmitter<E extends EventLog> extends AutoStartStopEventEmitter<AutoEventsEmitterEventsName<E>, EventsEmitterEmptyEvents> {
+  private readonly serialListeners?: boolean
+  private readonly serialProcessing?: boolean
+  private readonly newBlockEmitter: NewBlockEmitter
+  private readonly manualEmitter: ManualEventsEmitter<E>
+
+  private pollingUnsubscribe?: Function
+
+  constructor (eth: Eth, contract: Contract, blockTracker: BlockTracker, newBlockEmitter: NewBlockEmitter, baseLogger: Logger, options?: AutoEventsEmitterOptions) {
+    const logger = initLogger('events', baseLogger)
+    super(initLogger('', baseLogger), NEW_EVENT_EVENT_NAME, options?.autoStart)
+
+    this.manualEmitter = new ManualEventsEmitter(eth, contract, blockTracker, logger, options)
+    this.newBlockEmitter = newBlockEmitter
+    this.serialListeners = options?.serialListeners
+    this.serialProcessing = options?.serialProcessing
+
+    passTroughEvents(this.manualEmitter, this,
+      [
+        'error',
+        REORG_EVENT_NAME,
+        REORG_OUT_OF_RANGE_EVENT_NAME,
+        INVALID_CONFIRMATION_EVENT_NAME,
+        NEW_CONFIRMATION_EVENT_NAME
+      ]
+    )
+    this.newBlockEmitter.on('error', (e) => this.emit('error', e))
+  }
+
   private async emitEvents (events: E[]): Promise<void> {
     const emittingFnc = this.serialListeners ? this.emitSerial.bind(this) : this.emit.bind(this)
 
@@ -306,75 +383,47 @@ export abstract class BaseEventsEmitter<E extends EventLog> extends AutoStartSto
     }
   }
 
-  private serializeEvent (data: EventLog): EventInterface {
-    this.logger.debug(`New ${data.event} event to be confirmed. Block ${data.blockNumber}, transaction ${data.transactionHash}`)
-    return {
-      blockNumber: data.blockNumber,
-      transactionHash: data.transactionHash,
-      contractAddress: this.contract.address,
-      event: data.event,
-      targetConfirmation: this.confirmations,
-      content: JSON.stringify(data)
+  protected async convertIteratorToEmitter (iter: AsyncIterableIterator<Batch<E>>): Promise<void> {
+    for await (const batch of iter) {
+      await this.emitEvents(batch.events)
     }
-  }
-}
-
-/**
- * EventsEmitter implementation that uses polling for fetching new events from the blockchain.
- *
- * Polling is triggered using the NewBlockEmitter and is therefore up to the user
- * to chose what new-block strategy will employ.
- */
-export class PollingEventsEmitter<E extends EventLog> extends BaseEventsEmitter<E> {
-  private pollingUnsubscribe?: Function
-
-  constructor (eth: Eth, contract: Contract, blockTracker: BlockTracker, newBlockEmitter: NewBlockEmitter, baseLogger: Logger, options?: EventsEmitterOptions) {
-    const logger = initLogger('events', baseLogger)
-    super(eth, contract, blockTracker, newBlockEmitter, logger, options)
   }
 
   async poll (currentBlock: BlockHeader): Promise<void> {
     this.logger.verbose(`Received new block number ${currentBlock.number}`)
-    await this.semaphore.acquire()
-    this.logger.verbose(`Lock acquired for block ${currentBlock.number}`)
     try {
-      // Check if reorg did not happen since the last poll
-      if (this.confirmations && await this.isReorg()) {
-        return this.handleReorg(currentBlock)
-      }
-
-      const lastFetchedBlockNumber = this.blockTracker.getLastFetchedBlock()[0] ?? this.startingBlock
-
-      // Nothing new, lets fast-forward
-      if (lastFetchedBlockNumber === currentBlock.number) {
-        this.logger.verbose('Nothing new to process')
-        return
-      }
-
       await this.convertIteratorToEmitter(
-        this.batchFetchAndProcessEvents(
-          lastFetchedBlockNumber + 1, // +1 because fromBlock and toBlock are "or equal", eq. closed interval, so we need to avoid duplications
-          currentBlock.number,
-          currentBlock
-        )
+        this.manualEmitter.fetch(currentBlock)
       )
     } catch (e) {
       this.logger.error('Error in the processing loop:\n' + JSON.stringify(e, undefined, 2))
       this.emit('error', e)
-    } finally {
-      this.semaphore.release()
     }
   }
 
-  startEvents (): void {
+  async * fetch (toBlock: BlockHeader | undefined): AsyncIterableIterator<Batch<E>> {
+    yield * await this.manualEmitter.fetch(toBlock)
+  }
+
+  start (): void {
     this.logger.verbose('Starting listening on new blocks for polling new events')
     this.pollingUnsubscribe =
       this.newBlockEmitter.on(NEW_BLOCK_EVENT_NAME, errorHandler(this.poll.bind(this), this.logger))
   }
 
-  stopEvents (): void {
+  stop (): void {
     this.logger.verbose('Finishing listening on new blocks for polling new events')
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    this.pollingUnsubscribe && this.pollingUnsubscribe()
+
+    if (this.pollingUnsubscribe) {
+      this.pollingUnsubscribe()
+    }
+  }
+
+  get blockTracker (): BlockTracker {
+    return this.manualEmitter.blockTracker
+  }
+
+  get contract (): Contract {
+    return this.manualEmitter.contract
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,6 +58,19 @@ export function hashTopics (topics?: (string[] | string)[]): (string[] | string)
 }
 
 /**
+ * Subscribe to all events on "from" emitter and re-emit them in "to" emitter.
+ *
+ * @param from
+ * @param to
+ * @param events
+ */
+export function passTroughEvents (from: Emittery, to: Emittery, events: string[]): void {
+  for (const event of events) {
+    from.on(event, eventData => to.emit(event, eventData))
+  }
+}
+
+/**
  * Function that will split array into two groups based on callback that returns Promise.
  *
  * @param arr

--- a/test/events.spec.ts
+++ b/test/events.spec.ts
@@ -7,18 +7,17 @@ import chaiAsPromised from 'chai-as-promised'
 import util from 'util'
 import sinonChai from 'sinon-chai'
 import { Sequelize } from 'sequelize'
-import { EventData } from 'web3-eth-contract'
 import Emittery from 'emittery'
 
-import { BaseEventsEmitter, PollingEventsEmitter } from '../src/events'
+import { ManualEventsEmitter, AutoEventsEmitter } from '../src/events'
 import { loggingFactory } from '../src/utils'
 import { Event } from '../src/event.model'
-import { blockMock, delayedPromise, eventMock, sequelizeFactory, sleep, wholeGenerator } from './utils'
+import { blockMock, delayedPromise, eventMock, receiptMock, sequelizeFactory, sleep, wholeGenerator } from './utils'
 import {
+  AutoEventsEmitterOptions,
   BlockTracker,
   Contract,
-  EventsEmitterOptions,
-  Logger,
+  ManualEventsEmitterOptions,
   ModelConfirmator,
   NEW_BLOCK_EVENT_NAME,
   NEW_EVENT_EVENT_NAME,
@@ -33,32 +32,7 @@ chai.use(dirtyChai)
 const expect = chai.expect
 const setImmediatePromise = util.promisify(setImmediate)
 
-/**
- * Dummy implementation for testing BaseEventsEmitter
- */
-export class DummyEventsEmitter extends BaseEventsEmitter<EventData> {
-  constructor (eth: Eth, contract: Contract, blockTracker: BlockTracker, newBlockEmitter: NewBlockEmitter, options?: EventsEmitterOptions, name?: string) {
-    let logger: Logger
-
-    if (!name) {
-      logger = loggingFactory('web3events:events:dummy')
-    } else {
-      logger = loggingFactory('web3events:events:' + name)
-    }
-
-    super(eth, contract, blockTracker, newBlockEmitter, logger, options)
-  }
-
-  startEvents (): void {
-    // noop
-  }
-
-  stopEvents (): void {
-    // noop
-  }
-}
-
-describe('BaseEventsEmitter', () => {
+describe('ManualEventsEmitter', () => {
   let sequelize: Sequelize
 
   before((): void => {
@@ -86,10 +60,8 @@ describe('BaseEventsEmitter', () => {
     contract.getPastEvents(Arg.all()).returns(getPastEventsPromise) // Blocks the getPastEvents call
 
     const blockTracker = new BlockTracker({})
-    const newBlockEmitter = new Emittery()
     const options = { events: ['testEvent'] }
-    const spy = sinon.spy()
-    const eventsEmitter = new DummyEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, options)
+    const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:events:dummy'), options)
 
     // Directly fetch(), which should be blocked by the processing of previous events()
     const createEventPromise = wholeGenerator(eventsEmitter.fetch())
@@ -105,114 +77,524 @@ describe('BaseEventsEmitter', () => {
     eth.received(1).getBlock('latest')
   })
 
-  describe('fetch', function () {
-    it('should fetch everything from start if nothing processed yet', async function () {
-      const events = [
-        eventMock({ blockNumber: 4, transactionHash: '1' }),
-        eventMock({ blockNumber: 8, transactionHash: '2' }),
-        eventMock({ blockNumber: 9, transactionHash: '3' }),
-        eventMock({ blockNumber: 10, transactionHash: '4' })
-      ]
+  it('should ignore same blocks', async function () {
+    const events = [
+      eventMock({ blockNumber: 4, transactionHash: '1' }),
+      eventMock({ blockNumber: 8, transactionHash: '2' }),
+      eventMock({ blockNumber: 9, transactionHash: '3' }),
+      eventMock({ blockNumber: 10, transactionHash: '4' })
+    ]
 
+    const eth = Substitute.for<Eth>()
+    eth.getBlock('latest').resolves(blockMock(11))
+    // Required because for every batch the last block header is retrieved for setting the lastFetchedBlock
+    eth.getBlock(11).resolves(blockMock(11))
+
+    const contract = Substitute.for<Contract>()
+    contract.getPastEvents(Arg.all()).resolves(events)
+
+    const blockTracker = new BlockTracker({})
+    const options = { events: ['testEvent'] }
+    const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:events:dummy'), options)
+
+    const fetchedEvents = await wholeGenerator(eventsEmitter.fetch())
+
+    // Second time calling fetch for same block 11
+    const fetchedEventsSecondTime = await wholeGenerator(eventsEmitter.fetch())
+
+    expect(fetchedEvents).to.have.length(1)
+    expect(fetchedEvents[0].events).to.have.length(4)
+    expect(fetchedEvents[0].stepFromBlock).to.eql(0)
+    expect(fetchedEvents[0].stepToBlock).to.eql(11)
+
+    expect(fetchedEventsSecondTime).to.have.length(0)
+
+    eth.received(2).getBlock('latest') // Latest block will be called twice
+    contract.received(1).getPastEvents('allEvents', { // But getPastEvents should be only once
+      fromBlock: 0,
+      toBlock: 11,
+      topics: []
+    })
+  })
+
+  it('should thrown when from block is bigger then to block', async function () {
+    const contract = Substitute.for<Contract>()
+    const eth = Substitute.for<Eth>()
+    eth.getBlock('latest').resolves(blockMock(11))
+
+    const blockTracker = new BlockTracker({})
+    blockTracker.setLastFetchedBlock(13, '0x123')
+    const options = { events: ['testEvent'] }
+    const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:events:dummy'), options)
+
+    await expect(wholeGenerator(eventsEmitter.fetch())).to.be.rejectedWith('fromBlock has to be smaller then toBlock!')
+  })
+
+  describe('batch processing', function () {
+    it('should work in batches and emit progress info', async () => {
       const eth = Substitute.for<Eth>()
-      eth.getBlock('latest').resolves(blockMock(11))
+      eth.getBlock(14).resolves(blockMock(14))
+      eth.getBlock(19).resolves(blockMock(19))
+      eth.getBlock(24).resolves(blockMock(14))
+      eth.getBlock(25).resolves(blockMock(25))
+      eth.getBlock(29).resolves(blockMock(29))
+      eth.getBlock(31).resolves(blockMock(31))
 
       const contract = Substitute.for<Contract>()
-      contract.getPastEvents(Arg.all()).resolves(events)
+      contract.getPastEvents(Arg.all()).resolves(
+        [eventMock({ blockHash: '0x123', blockNumber: 10 })],
+        [eventMock({ blockHash: '0x123', blockNumber: 16 })],
+        [eventMock({ blockHash: '0x123', blockNumber: 21 })],
+        [eventMock({ blockHash: '0x123', blockNumber: 25 })],
+        [eventMock({ blockHash: '0x123', blockNumber: 26 })],
+        [eventMock({ blockHash: '0x123', blockNumber: 31 })]
+      )
 
       const blockTracker = new BlockTracker({})
-      const newBlockEmitter = new Emittery()
-      const options = { events: ['testEvent'] }
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, options)
+      blockTracker.setLastFetchedBlock(9, '0x123')
+      const lastFetchedBlockSetSpy = sinon.spy()
+      blockTracker.on('fetchedBlockSet', lastFetchedBlockSetSpy)
 
-      // Directly fetch(), which should be blocked by the processing of previous events()
-      const fetchedEvents = await wholeGenerator(eventsEmitter.fetch())
+      const options: ManualEventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
+      const progressInfoSpy = sinon.spy()
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      eventsEmitter.on(PROGRESS_EVENT_NAME, progressInfoSpy)
+      await setImmediatePromise() // Have to give enough time for the subscription to newBlockEmitter was picked up
 
-      expect(fetchedEvents).to.have.length(1)
-      expect(fetchedEvents[0].events).to.have.length(4)
-      expect(fetchedEvents[0].stepFromBlock).to.eql(0)
-      expect(fetchedEvents[0].stepToBlock).to.eql(11)
-      eth.received(1).getBlock('latest')
-      contract.received(1).getPastEvents('allEvents', {
-        fromBlock: 0,
-        toBlock: 11,
-        topics: []
+      // As it is closed interval it should lead to 4 batches: 3*5 + 1
+      const firstCall = await wholeGenerator(eventsEmitter.fetch(blockMock(25))) // Fire up the first processing
+      // Second processing should have 2 batches
+      const secondCall = await wholeGenerator(eventsEmitter.fetch(blockMock(31))) // Fire up the first processing
+
+      expect(firstCall).to.have.length(4)
+      expect(secondCall).to.have.length(2)
+
+      const TOTAL_BATCHES = 6
+      eth.received(TOTAL_BATCHES).getBlock(Arg.all())
+      contract.received(TOTAL_BATCHES).getPastEvents(Arg.all())
+      expect(lastFetchedBlockSetSpy).to.have.callCount(TOTAL_BATCHES)
+      expect(progressInfoSpy).to.have.callCount(TOTAL_BATCHES)
+      expect(blockTracker.getLastFetchedBlock()).to.eql([31, '0x123'])
+      expect(progressInfoSpy.firstCall).to.calledWithExactly({
+        stepsComplete: 1,
+        totalSteps: 4,
+        stepFromBlock: 10,
+        stepToBlock: 14
+      })
+      expect(progressInfoSpy.secondCall).to.calledWithExactly({
+        stepsComplete: 2,
+        totalSteps: 4,
+        stepFromBlock: 15,
+        stepToBlock: 19
+      })
+      expect(progressInfoSpy.thirdCall).to.calledWithExactly({
+        stepsComplete: 3,
+        totalSteps: 4,
+        stepFromBlock: 20,
+        stepToBlock: 24
+      })
+      expect(progressInfoSpy.getCall(3)).to.calledWithExactly({
+        stepsComplete: 4,
+        totalSteps: 4,
+        stepFromBlock: 25,
+        stepToBlock: 25
+      })
+      expect(progressInfoSpy.getCall(4)).to.calledWithExactly({
+        stepsComplete: 1,
+        totalSteps: 2,
+        stepFromBlock: 26,
+        stepToBlock: 30
+      })
+      expect(progressInfoSpy.getCall(5)).to.calledWithExactly({
+        stepsComplete: 2,
+        totalSteps: 2,
+        stepFromBlock: 31,
+        stepToBlock: 31
       })
     })
 
-    it('should fetch everything from last processed block', async function () {
-      const events = [
-        eventMock({ blockNumber: 4, transactionHash: '1' }),
-        eventMock({ blockNumber: 8, transactionHash: '2' }),
-        eventMock({ blockNumber: 9, transactionHash: '3' }),
-        eventMock({ blockNumber: 10, transactionHash: '4' })
-      ]
-
+    it('should correctly fetch only one block', async () => {
       const eth = Substitute.for<Eth>()
-      eth.getBlock('latest').resolves(blockMock(11))
+      eth.getBlock(25).resolves(blockMock(25))
 
       const contract = Substitute.for<Contract>()
-      contract.getPastEvents(Arg.all()).resolves(events)
+      contract.getPastEvents(Arg.all()).resolves(
+        [eventMock({ blockHash: '0x123', blockNumber: 25 })]
+      )
 
       const blockTracker = new BlockTracker({})
-      blockTracker.setLastFetchedBlock(3, '0x123')
+      blockTracker.setLastFetchedBlock(24, '0x123')
+      const lastFetchedBlockSetSpy = sinon.spy()
+      blockTracker.on('fetchedBlockSet', lastFetchedBlockSetSpy)
 
-      const newBlockEmitter = new Emittery()
-      const options = { events: ['testEvent'] }
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, options)
+      const options: ManualEventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
+      const progressInfoSpy = sinon.spy()
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      eventsEmitter.on(PROGRESS_EVENT_NAME, progressInfoSpy)
 
-      // Directly fetch(), which should be blocked by the processing of previous events()
-      const fetchedEvents = await wholeGenerator(eventsEmitter.fetch())
+      const firstCall = await wholeGenerator(eventsEmitter.fetch(blockMock(25))) // Fire up the first processing
 
-      expect(fetchedEvents).to.have.length(1)
-      expect(fetchedEvents[0].events).to.have.length(4)
-      expect(fetchedEvents[0].stepFromBlock).to.eql(3)
-      expect(fetchedEvents[0].stepToBlock).to.eql(11)
-      eth.received(1).getBlock('latest')
-      contract.received(1).getPastEvents('allEvents', {
-        fromBlock: 3,
-        toBlock: 11,
-        topics: []
+      expect(firstCall).to.have.length(1)
+
+      const TOTAL_BATCHES = 1
+      eth.received(TOTAL_BATCHES).getBlock(Arg.all())
+      contract.received(TOTAL_BATCHES).getPastEvents(Arg.all())
+      expect(lastFetchedBlockSetSpy).to.have.callCount(TOTAL_BATCHES)
+      expect(progressInfoSpy).to.have.callCount(TOTAL_BATCHES)
+      expect(progressInfoSpy).to.calledOnceWithExactly({
+        stepsComplete: 1,
+        totalSteps: 1,
+        stepFromBlock: 25,
+        stepToBlock: 25
       })
+      expect(blockTracker.getLastFetchedBlock()).to.eql([25, '0x123'])
+    })
+  })
+  describe('reorg handling', function () {
+    it('should handle reorg without nothing processed yet', async () => {
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
+
+      const mockedEvents = [
+        {
+          contractAddress: '0x123',
+          event: 'testEvent',
+          blockNumber: 7,
+          transactionHash: '1',
+          targetConfirmation: 3,
+          emitted: true,
+          content: '{"event": "testEvent", "blockNumber": 7, "blockHash": "0x123"}'
+        },
+        {
+          contractAddress: '0x123',
+          event: 'testEvent',
+          blockNumber: 8,
+          transactionHash: '2',
+          targetConfirmation: 4,
+          emitted: false,
+          content: '{"event": "testEvent", "blockNumber": 8, "blockHash": "0x123"}'
+        },
+        {
+          contractAddress: '0x666',
+          event: 'niceEvent',
+          blockNumber: 9,
+          transactionHash: '3',
+          targetConfirmation: 2,
+          emitted: false,
+          content: '{"event": "niceEvent", "blockNumber": 9, "blockHash": "0x123"}'
+        }
+      ]
+      await Event.bulkCreate(mockedEvents)
+
+      const contract = Substitute.for<Contract>()
+      contract.address.returns!('0x123')
+      contract.getPastEvents(Arg.all()).resolves(
+        [eventMock({ blockNumber: 11, transactionHash: '1' })]
+      )
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastFetchedBlock(10, '0x123')
+
+      const options = {
+        confirmations: 1,
+        confirmator: Substitute.for<ModelConfirmator<any>>(),
+        events: ['testEvent']
+      }
+      const reorgSpy = sinon.spy()
+      const reorgOutOfRangeSpy = sinon.spy()
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
+      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
+      await setImmediatePromise()
+
+      const events = await wholeGenerator(eventsEmitter.fetch(blockMock(11)))
+
+      contract.received(1).getPastEvents(Arg.all())
+      eth.received(1).getBlock(Arg.all())
+      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
+      expect(events).to.have.length(0)
+      expect(reorgSpy).to.have.callCount(1)
+      expect(reorgOutOfRangeSpy).to.have.callCount(0)
+      expect(await Event.count()).to.eql(2)
     })
 
-    it('should not fetch events which needs confirmations', async function () {
+    it('should handle reorg with already processed events', async () => {
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
+      eth.getBlock(8).resolves(blockMock(8, '0x222')) // Same hash ==> reorg in confirmation range
+
+      const contract = Substitute.for<Contract>()
+      contract.address.returns!('0x123')
+      contract.getPastEvents('allEvents', { fromBlock: 9, toBlock: 11 }).resolves( // 9 because we don't want to reprocess 8th already processed block
+        [eventMock({ blockNumber: 11, transactionHash: '1' })]
+      )
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastFetchedBlock(10, '0x123')
+      blockTracker.setLastProcessedBlockIfHigher(8, '0x222')
+
+      const options = {
+        confirmations: 1,
+        confirmator: Substitute.for<ModelConfirmator<any>>(),
+        events: ['testEvent']
+      }
+      const reorgSpy = sinon.spy()
+      const reorgOutOfRangeSpy = sinon.spy()
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
+      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
+      await setImmediatePromise()
+
+      const events = await wholeGenerator(eventsEmitter.fetch(blockMock(11)))
+
+      contract.received(1).getPastEvents('allEvents', { fromBlock: 9, toBlock: 11 })
+      eth.received(2).getBlock(Arg.all())
+      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
+      expect(events).to.have.length(0)
+      expect(reorgSpy).to.have.callCount(1)
+      expect(reorgOutOfRangeSpy).to.have.callCount(0)
+      expect(await Event.count()).to.eql(1)
+    })
+
+    it('should handle reorg and detect reorg outside of confirmation range', async () => {
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
+      eth.getBlock(8).resolves(blockMock(8, '0x33')) // Different hash ==> reorg OUTSIDE of confirmation range
+
+      const contract = Substitute.for<Contract>()
+      contract.address.returns!('0x123')
+      contract.getPastEvents(Arg.all()).resolves(
+        [eventMock({ blockNumber: 11, transactionHash: '1' })]
+      )
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastFetchedBlock(10, '0x123')
+      blockTracker.setLastProcessedBlockIfHigher(8, '0x222')
+
+      const options = {
+        confirmations: 1,
+        confirmator: Substitute.for<ModelConfirmator<any>>(),
+        events: ['testEvent']
+      }
+      const reorgSpy = sinon.spy()
+      const reorgOutOfRangeSpy = sinon.spy()
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
+      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
+      await setImmediatePromise()
+
+      const events = await wholeGenerator(eventsEmitter.fetch(blockMock(11)))
+
+      contract.received(1).getPastEvents(Arg.all())
+      eth.received(2).getBlock(Arg.all())
+      expect(events).to.have.length(0)
+      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
+      expect(reorgSpy).to.have.callCount(1)
+      expect(reorgOutOfRangeSpy).to.have.callCount(1)
+      expect(await Event.count()).to.eql(1)
+    })
+  })
+
+  describe('with confirmations', () => {
+    it('should process past events', async function () {
       const events = [
-        eventMock({ blockNumber: 4, transactionHash: '1' }),
-        eventMock({ blockNumber: 8, transactionHash: '2' }),
-        eventMock({ blockNumber: 9, transactionHash: '3' }),
-        eventMock({ blockNumber: 10, transactionHash: '4' })
+        eventMock({ blockHash: '0x123', blockNumber: 1, transactionHash: '1' }),
+        eventMock({ blockHash: '0x125', blockNumber: 8, transactionHash: '2' }),
+        eventMock({ blockHash: '0x123', blockNumber: 9, transactionHash: '3' }),
+        eventMock({ blockHash: '0x123', blockNumber: 10, transactionHash: '4' })
       ]
 
       const eth = Substitute.for<Eth>()
-      eth.getBlock('latest').resolves(blockMock(11))
+      eth.getBlock(10).resolves(blockMock(10))
 
       const contract = Substitute.for<Contract>()
       contract.getPastEvents(Arg.all()).resolves(events)
 
       const blockTracker = new BlockTracker({})
-      const newBlockEmitter = new Emittery()
-      const options = { events: ['testEvent'], confirmations: 2, confirmator: null }
-      const eventsEmitter = new DummyEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, options)
+      // We deliberately disable Confirmator in order not to intervene with our assertions
+      const options: ManualEventsEmitterOptions = {
+        confirmations: 2,
+        events: ['testEvent'],
+        confirmator: null,
+        startingBlock: 0
+      }
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
 
-      // Directly fetch(), which should be blocked by the processing of previous events()
-      const fetchedEvents = await wholeGenerator(eventsEmitter.fetch())
+      const confirmedEvents = await wholeGenerator(eventsEmitter.fetch(blockMock(10)))
 
-      expect(fetchedEvents).to.have.length(1)
-      expect(fetchedEvents[0].events).to.have.length(3)
-      expect(fetchedEvents[0].stepFromBlock).to.eql(0)
-      expect(fetchedEvents[0].stepToBlock).to.eql(11)
-      eth.received(1).getBlock('latest')
-      contract.received(1).getPastEvents('allEvents', {
-        fromBlock: 0,
-        toBlock: 11,
-        topics: []
-      })
+      expect(confirmedEvents).to.have.length(1)
+      expect(confirmedEvents[0].stepFromBlock).to.eql(0)
+      expect(confirmedEvents[0].stepToBlock).to.eql(10)
+      expect(confirmedEvents[0].events).to.have.length(2) // 2 events emitted
+      contract.received(1).getPastEvents(Arg.all())
+      expect(await Event.count()).to.eql(2)
+      expect(blockTracker.getLastProcessedBlock()).to.eql([8, '0x125'])
+      expect(blockTracker.getLastFetchedBlock()).to.eql([10, '0x123'])
+    })
+
+    it('should process new events', async function () {
+      const events = [
+        eventMock({ blockNumber: 4, blockHash: '0x123', transactionHash: '1' }),
+        eventMock({ blockNumber: 8, blockHash: '0x123', transactionHash: '2' }),
+        eventMock({ blockNumber: 9, blockHash: '0x123', transactionHash: '3' }),
+        eventMock({ blockNumber: 10, blockHash: '0x123', transactionHash: '4' })
+      ]
+
+      const contract = Substitute.for<Contract>()
+      contract.address.returns!('0x123')
+      contract.getPastEvents(Arg.all()).resolves(events)
+
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(3).resolves(blockMock(3, '0x11111'))
+      eth.getBlock(8).resolves(blockMock(8))
+      eth.getBlock(10).resolves(blockMock(10))
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastFetchedBlock(3, '0x11111')
+
+      // We deliberately disable Confirmator in order not to intervene with our assertions
+      const options = { confirmations: 2, events: ['testEvent'], confirmator: null }
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      const confirmedEvents = await wholeGenerator(eventsEmitter.fetch(blockMock(10)))
+
+      expect(confirmedEvents).to.have.length(1)
+      expect(confirmedEvents[0].stepFromBlock).to.eql(4)
+      expect(confirmedEvents[0].stepToBlock).to.eql(10)
+      expect(blockTracker.getLastFetchedBlock()).to.eql([10, '0x123'])
+      expect(blockTracker.getLastProcessedBlock()).to.eql([8, '0x123'])
+      expect(confirmedEvents[0].events).to.have.length(2) // 2 events emitted
+      expect(await Event.count()).to.eql(2)
+      contract.received(1).getPastEvents(Arg.all())
+    })
+
+    it('should confirm saved events', async function () {
+      const savedEvents = [
+        { // Emitted newEvent
+          contractAddress: '0x123',
+          event: 'testEvent',
+          blockNumber: 9,
+          transactionHash: '3',
+          targetConfirmation: 2,
+          emitted: false,
+          content: '{"event": "niceEvent", "blockNumber": 9, "blockHash": "0x123"}'
+        },
+        { // Emitted newEvent
+          contractAddress: '0x123',
+          event: 'testEvent',
+          blockNumber: 9,
+          transactionHash: '3',
+          targetConfirmation: 2,
+          emitted: false,
+          content: '{"event": "otherEvent", "blockNumber": 9, "blockHash": "0x123"}'
+        }
+      ]
+      await Event.bulkCreate(savedEvents)
+
+      const contract = Substitute.for<Contract>()
+      contract.address.returns!('0x123')
+      contract.getPastEvents(Arg.all()).resolves(
+        [eventMock({ blockNumber: 12, blockHash: '0x123', transactionHash: '3' })],
+        [eventMock({ blockNumber: 14, blockHash: '0x123', transactionHash: '4' })]
+      )
+
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10))
+      eth.getBlock(12).resolves(blockMock(12))
+      eth.getBlock(14).resolves(blockMock(14))
+      eth.getTransactionReceipt('3').resolves(receiptMock(9))
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastProcessedBlockIfHigher(8, '0x123')
+      blockTracker.setLastFetchedBlock(10, '0x123')
+
+      const options = { confirmations: 2, events: ['testEvent'], batchSize: 2 }
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+
+      const confirmedEvents = await wholeGenerator(eventsEmitter.fetch(blockMock(14)))
+
+      expect(confirmedEvents).to.have.length(3)
+
+      // First batch is confirmed events
+      expect(confirmedEvents[0].stepFromBlock).to.eql(8)
+      expect(confirmedEvents[0].stepToBlock).to.eql(9)
+      expect(confirmedEvents[0].events).to.have.length(2) // 2 confirmed events
+      expect(confirmedEvents[0].events[0]).to.eql({ event: 'niceEvent', blockNumber: 9, blockHash: '0x123' })
+      expect(confirmedEvents[0].events[1]).to.eql({ event: 'otherEvent', blockNumber: 9, blockHash: '0x123' })
+
+      // Second batch is fetched events
+      expect(confirmedEvents[1].stepFromBlock).to.eql(11)
+      expect(confirmedEvents[1].stepToBlock).to.eql(12)
+      expect(confirmedEvents[1].events).to.have.length(1)
+
+      // Third batch is fetched events
+      expect(confirmedEvents[2].stepFromBlock).to.eql(13)
+      expect(confirmedEvents[2].stepToBlock).to.eql(14)
+      expect(confirmedEvents[2].events).to.have.length(0) // Nothing is emitted from fetched events as confirmations are needed
+
+      expect(blockTracker.getLastFetchedBlock()).to.eql([14, '0x123'])
+      expect(blockTracker.getLastProcessedBlock()).to.eql([12, '0x123'])
+      expect(await Event.count()).to.eql(3)
+      contract.received(2).getPastEvents(Arg.all())
+    })
+  })
+
+  describe('no confirmations', () => {
+    it('should process past events', async function () {
+      const events = [
+        eventMock({ blockNumber: 7, event: 'testEvent', returnValues: { hey: 123 } }),
+        eventMock({ blockNumber: 8, event: 'testEvent', returnValues: { hey: 123 } }),
+        eventMock({ blockNumber: 9, event: 'testEvent', returnValues: { hey: 123 } })
+      ]
+
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10))
+
+      const contract = Substitute.for<Contract>()
+      contract.getPastEvents(Arg.all()).resolves(events)
+
+      const blockTracker = new BlockTracker({})
+      const options: ManualEventsEmitterOptions = { events: ['testEvent'], startingBlock: 0 }
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+
+      const confirmedEvents = await wholeGenerator(eventsEmitter.fetch(blockMock(10)))
+
+      expect(confirmedEvents).to.have.length(1)
+      expect(confirmedEvents[0].events).to.have.length(3) // 3 events emitted
+      contract.received(1).getPastEvents(Arg.all())
+      expect(blockTracker.getLastFetchedBlock()).to.eql([10, '0x123'])
+    })
+
+    it('should emits new events', async function () {
+      const testEvent = eventMock()
+      const events = [
+        testEvent,
+        testEvent,
+        testEvent
+      ]
+
+      const eth = Substitute.for<Eth>()
+      eth.getBlock(10).resolves(blockMock(10))
+
+      const contract = Substitute.for<Contract>()
+      contract.getPastEvents(Arg.all()).resolves(events)
+
+      const blockTracker = new BlockTracker({})
+      blockTracker.setLastFetchedBlock(6, '')
+
+      const options = { events: ['testEvent'] }
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
+      const confirmedEvents = await wholeGenerator(eventsEmitter.fetch(blockMock(10)))
+
+      expect(confirmedEvents).to.have.length(1)
+      expect(confirmedEvents[0].events).to.have.length(3) // 3 events emitted
+      expect(blockTracker.getLastFetchedBlock()).to.eql([10, '0x123'])
+      contract.received(1).getPastEvents(Arg.all())
+      eth.received(1).getBlock(10)
     })
   })
 })
 
-describe('PollingEventsEmitter', function () {
+describe('AutoEventsEmitter', function () {
   let sequelize: Sequelize
 
   before((): void => {
@@ -243,9 +625,9 @@ describe('PollingEventsEmitter', function () {
       const blockTracker = new BlockTracker({})
       const newBlockEmitter = new Emittery()
       // We deliberately disable Confirmator in order not to intervene with our assertions
-      const options: EventsEmitterOptions = { confirmations: 2, events: ['testEvent'], confirmator: null }
+      const options: AutoEventsEmitterOptions = { confirmations: 2, events: ['testEvent'], confirmator: null }
       const spy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+      const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
       eventsEmitter.on(NEW_EVENT_EVENT_NAME, spy)
 
       await setImmediatePromise()
@@ -279,9 +661,9 @@ describe('PollingEventsEmitter', function () {
 
       const newBlockEmitter = new Emittery()
       // We deliberately disable Confirmator in order not to intervene with our assertions
-      const options: EventsEmitterOptions = { confirmations: 2, events: ['testEvent'], confirmator: null }
+      const options: ManualEventsEmitterOptions = { confirmations: 2, events: ['testEvent'], confirmator: null }
       const spy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+      const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
       eventsEmitter.on(NEW_EVENT_EVENT_NAME, spy)
 
       await setImmediatePromise()
@@ -311,7 +693,7 @@ describe('PollingEventsEmitter', function () {
       const newBlockEmitter = new Emittery()
       const options = { events: ['testEvent'] }
       const spy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+      const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
       eventsEmitter.on(NEW_EVENT_EVENT_NAME, spy)
       await setImmediatePromise()
 
@@ -342,7 +724,7 @@ describe('PollingEventsEmitter', function () {
       const newBlockEmitter = new Emittery()
       const options = { events: ['testEvent'] }
       const spy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+      const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
       eventsEmitter.on(NEW_EVENT_EVENT_NAME, spy)
 
       await setImmediatePromise() // Have to give enough time for the subscription to newBlockEmitter was picked up
@@ -375,7 +757,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
     eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -416,7 +798,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
     eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -446,8 +828,8 @@ describe('PollingEventsEmitter', function () {
 
     const blockTracker = new BlockTracker({})
     const newBlockEmitter = new Emittery()
-    const options: EventsEmitterOptions = { events: ['testEvent'], serialListeners: true }
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const options: AutoEventsEmitterOptions = { events: ['testEvent'], serialListeners: true }
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
 
     const spy1 = sinon.spy()
     const [listener1Promise, listener1Callback] = delayedPromise()
@@ -520,7 +902,7 @@ describe('PollingEventsEmitter', function () {
     const blockTracker = new BlockTracker({})
     const newBlockEmitter = new Emittery()
     const options = { events: ['testEvent'], serialProcessing: true }
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
 
     const spy = sinon.spy()
     let releaseCb: Function
@@ -578,7 +960,7 @@ describe('PollingEventsEmitter', function () {
     const newEventSpy = sinon.spy()
     const reorgSpy = sinon.spy()
     const reorgOutOfRangeSpy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
     eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
     eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
     eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
@@ -617,7 +999,7 @@ describe('PollingEventsEmitter', function () {
     const newBlockEmitter = new Emittery()
     const options = { events: ['testEvent'] }
     const spy = sinon.spy()
-    const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
+    const eventsEmitter = new AutoEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
     eventsEmitter.on(NEW_EVENT_EVENT_NAME, spy) // Will start processPastEvents() which will be delayed
     await setImmediatePromise() // Have to give enough time for the subscription to newBlockEmitter was picked up
 
@@ -671,19 +1053,19 @@ describe('PollingEventsEmitter', function () {
       const lastFetchedBlockSetSpy = sinon.spy()
       blockTracker.on('fetchedBlockSet', lastFetchedBlockSetSpy)
 
-      const newBlockEmitter = new Emittery()
-      const options: EventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
-      const newEventSpy = sinon.spy()
+      const options: ManualEventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
       const progressInfoSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
-      eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
       eventsEmitter.on(PROGRESS_EVENT_NAME, progressInfoSpy)
       await setImmediatePromise() // Have to give enough time for the subscription to newBlockEmitter was picked up
 
       // As it is closed interval it should lead to 4 batches: 3*5 + 1
-      await newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(25)) // Fire up the first processing
+      const firstCall = await wholeGenerator(eventsEmitter.fetch(blockMock(25))) // Fire up the first processing
       // Second processing should have 2 batches
-      await newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(31)) // Fire up the second processing
+      const secondCall = await wholeGenerator(eventsEmitter.fetch(blockMock(31))) // Fire up the first processing
+
+      expect(firstCall).to.have.length(4)
+      expect(secondCall).to.have.length(2)
 
       const TOTAL_BATCHES = 6
       eth.received(TOTAL_BATCHES).getBlock(Arg.all())
@@ -743,17 +1125,14 @@ describe('PollingEventsEmitter', function () {
       const lastFetchedBlockSetSpy = sinon.spy()
       blockTracker.on('fetchedBlockSet', lastFetchedBlockSetSpy)
 
-      const newBlockEmitter = new Emittery()
-      const options: EventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
-      const newEventSpy = sinon.spy()
+      const options: ManualEventsEmitterOptions = { events: ['testEvent'], batchSize: 5 }
       const progressInfoSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
-      eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
+      const eventsEmitter = new ManualEventsEmitter(eth, contract, blockTracker, loggingFactory('web3events:test'), options)
       eventsEmitter.on(PROGRESS_EVENT_NAME, progressInfoSpy)
-      await setImmediatePromise() // Have to give enough time for the subscription to newBlockEmitter was picked up
 
-      newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(25)) // Fire up the processing
-      await setImmediatePromise()
+      const firstCall = await wholeGenerator(eventsEmitter.fetch(blockMock(25))) // Fire up the first processing
+
+      expect(firstCall).to.have.length(1)
 
       const TOTAL_BATCHES = 1
       eth.received(TOTAL_BATCHES).getBlock(Arg.all())
@@ -767,163 +1146,6 @@ describe('PollingEventsEmitter', function () {
         stepToBlock: 25
       })
       expect(blockTracker.getLastFetchedBlock()).to.eql([25, '0x123'])
-    })
-  })
-
-  describe('reorg handling', function () {
-    it('should handle reorg without nothing processed yet', async () => {
-      const eth = Substitute.for<Eth>()
-      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
-
-      const events = [
-        {
-          contractAddress: '0x123',
-          event: 'testEvent',
-          blockNumber: 7,
-          transactionHash: '1',
-          targetConfirmation: 3,
-          emitted: true,
-          content: '{"event": "testEvent", "blockNumber": 7, "blockHash": "0x123"}'
-        },
-        {
-          contractAddress: '0x123',
-          event: 'testEvent',
-          blockNumber: 8,
-          transactionHash: '2',
-          targetConfirmation: 4,
-          emitted: false,
-          content: '{"event": "testEvent", "blockNumber": 8, "blockHash": "0x123"}'
-        },
-        {
-          contractAddress: '0x666',
-          event: 'niceEvent',
-          blockNumber: 9,
-          transactionHash: '3',
-          targetConfirmation: 2,
-          emitted: false,
-          content: '{"event": "niceEvent", "blockNumber": 9, "blockHash": "0x123"}'
-        }
-      ]
-      await Event.bulkCreate(events)
-
-      const contract = Substitute.for<Contract>()
-      contract.address.returns!('0x123')
-      contract.getPastEvents(Arg.all()).resolves(
-        [eventMock({ blockNumber: 11, transactionHash: '1' })]
-      )
-
-      const blockTracker = new BlockTracker({})
-      blockTracker.setLastFetchedBlock(10, '0x123')
-
-      const newBlockEmitter = new Emittery()
-      const options = {
-        confirmations: 1,
-        confirmator: Substitute.for<ModelConfirmator>(),
-        events: ['testEvent']
-      }
-      const newEventSpy = sinon.spy()
-      const reorgSpy = sinon.spy()
-      const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
-      eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
-      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
-      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
-      await setImmediatePromise()
-
-      newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(11))
-      await sleep(200)
-
-      contract.received(1).getPastEvents(Arg.all())
-      eth.received(1).getBlock(Arg.all())
-      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
-      expect(newEventSpy).to.have.callCount(0)
-      expect(reorgSpy).to.have.callCount(1)
-      expect(reorgOutOfRangeSpy).to.have.callCount(0)
-      expect(await Event.count()).to.eql(2)
-    })
-
-    it('should handle reorg with already processed', async () => {
-      const eth = Substitute.for<Eth>()
-      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
-      eth.getBlock(8).resolves(blockMock(8, '0x222')) // Same hash ==> reorg in confirmation range
-
-      const contract = Substitute.for<Contract>()
-      contract.address.returns!('0x123')
-      contract.getPastEvents('allEvents', { fromBlock: 9, toBlock: 11 }).resolves( // 9 because we don't want to reprocess 8th already processed block
-        [eventMock({ blockNumber: 11, transactionHash: '1' })]
-      )
-
-      const blockTracker = new BlockTracker({})
-      blockTracker.setLastFetchedBlock(10, '0x123')
-      blockTracker.setLastProcessedBlockIfHigher(8, '0x222')
-
-      const newBlockEmitter = new Emittery()
-      const options = {
-        confirmations: 1,
-        confirmator: Substitute.for<ModelConfirmator>(),
-        events: ['testEvent']
-      }
-      const newEventSpy = sinon.spy()
-      const reorgSpy = sinon.spy()
-      const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
-      eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
-      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
-      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
-      await setImmediatePromise()
-
-      newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(11))
-      await sleep(200)
-
-      contract.received(1).getPastEvents('allEvents', { fromBlock: 9, toBlock: 11 })
-      eth.received(2).getBlock(Arg.all())
-      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
-      expect(newEventSpy).to.have.callCount(0)
-      expect(reorgSpy).to.have.callCount(1)
-      expect(reorgOutOfRangeSpy).to.have.callCount(0)
-      expect(await Event.count()).to.eql(1)
-    })
-
-    it('should handle reorg and detect reorg outside of confirmation range', async () => {
-      const eth = Substitute.for<Eth>()
-      eth.getBlock(10).resolves(blockMock(10, '0x321')) // Different hash ==> reorg
-      eth.getBlock(8).resolves(blockMock(8, '0x33')) // Different hash ==> reorg OUTSIDE of confirmation range
-
-      const contract = Substitute.for<Contract>()
-      contract.address.returns!('0x123')
-      contract.getPastEvents(Arg.all()).resolves(
-        [eventMock({ blockNumber: 11, transactionHash: '1' })]
-      )
-
-      const blockTracker = new BlockTracker({})
-      blockTracker.setLastFetchedBlock(10, '0x123')
-      blockTracker.setLastProcessedBlockIfHigher(8, '0x222')
-
-      const newBlockEmitter = new Emittery()
-      const options = {
-        confirmations: 1,
-        confirmator: Substitute.for<ModelConfirmator>(),
-        events: ['testEvent']
-      }
-      const newEventSpy = sinon.spy()
-      const reorgSpy = sinon.spy()
-      const reorgOutOfRangeSpy = sinon.spy()
-      const eventsEmitter = new PollingEventsEmitter(eth, contract, blockTracker, newBlockEmitter as NewBlockEmitter, loggingFactory('web3events:test'), options)
-      eventsEmitter.on(NEW_EVENT_EVENT_NAME, newEventSpy)
-      eventsEmitter.on(REORG_EVENT_NAME, reorgSpy)
-      eventsEmitter.on(REORG_OUT_OF_RANGE_EVENT_NAME, reorgOutOfRangeSpy)
-      await setImmediatePromise()
-
-      newBlockEmitter.emit(NEW_BLOCK_EVENT_NAME, blockMock(11))
-      await sleep(200)
-
-      contract.received(1).getPastEvents(Arg.all())
-      eth.received(2).getBlock(Arg.all())
-      expect(blockTracker.getLastFetchedBlock()).to.eql([11, '0x123'])
-      expect(newEventSpy).to.have.callCount(0)
-      expect(reorgSpy).to.have.callCount(1)
-      expect(reorgOutOfRangeSpy).to.have.callCount(1)
-      expect(await Event.count()).to.eql(1)
     })
   })
 })

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -5,7 +5,8 @@ import dirtyChai from 'dirty-chai'
 import sinon from 'sinon'
 import util from 'util'
 
-import { AutoStartStopEventEmitter, loggingFactory } from '../src/utils'
+import { AutoStartStopEventEmitter, loggingFactory, passTroughEvents } from '../src/utils'
+import Emittery from 'emittery'
 
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
@@ -90,6 +91,32 @@ describe('utils', () => {
       emitter.on(EVENT_NAME, listenerSpy)
       await setImmediatePromise()
       expect(startSpy).to.be.calledTwice()
+    })
+  })
+
+  describe('passThroughEvents', function () {
+    it('should pass events when emitted', async () => {
+      const emitterFrom = new Emittery()
+      const emitterTo = new Emittery()
+      const spyOne = sinon.spy()
+      const spyTwo = sinon.spy()
+
+      passTroughEvents(emitterFrom, emitterTo, ['one'])
+
+      emitterTo.on('one', spyOne)
+      emitterTo.on('two', spyOne)
+
+      expect(spyOne).not.to.be.called()
+      expect(spyTwo).not.to.be.called()
+      emitterFrom.emit('one')
+      await setImmediatePromise()
+
+      expect(spyOne).to.be.calledOnce()
+      expect(spyTwo).not.to.be.called()
+      emitterFrom.emit('two')
+      await setImmediatePromise()
+
+      expect(spyTwo).not.to.be.called()
     })
   })
 })


### PR DESCRIPTION
This refactors the original `BaseEventsEmitter` abstract class into normal class `ManualEmitter` which has the method `fetch()`.

Originally the method `fetch()` was not really doing all the things it was supposed to like:

 - handle reorgs
 - confirm events that were saved to DB

Also I refactored the `PollingEventsEmitter` into `AutoEventsEmitter` that is triggered by new block, calls `fetch()` and emit those events.